### PR TITLE
Fix/dtos budget maximum allowed

### DIFF
--- a/src/categories/dto/create-category.dto.spec.ts
+++ b/src/categories/dto/create-category.dto.spec.ts
@@ -1,0 +1,49 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { CreateCategoryDto } from './create-category.dto';
+
+describe('CreateCategoryDto', () => {
+  const validDto = {
+    name: 'Groceries',
+    budgetAmount: 100000,
+  };
+
+  describe('budgetAmount @Max constraint', () => {
+    it('should accept budgetAmount at the maximum value (9999999999999)', async () => {
+      const dto = plainToInstance(CreateCategoryDto, {
+        ...validDto,
+        budgetAmount: 9999999999999,
+      });
+
+      const errors = await validate(dto);
+      const budgetErrors = errors.filter((e) => e.property === 'budgetAmount');
+
+      expect(budgetErrors).toHaveLength(0);
+    });
+
+    it('should reject budgetAmount exceeding the maximum value', async () => {
+      const dto = plainToInstance(CreateCategoryDto, {
+        ...validDto,
+        budgetAmount: 10000000000000,
+      });
+
+      const errors = await validate(dto);
+      const budgetErrors = errors.filter((e) => e.property === 'budgetAmount');
+
+      expect(budgetErrors).toHaveLength(1);
+      expect(budgetErrors[0].constraints).toHaveProperty('max');
+    });
+
+    it('should accept budgetAmount at the minimum value (0)', async () => {
+      const dto = plainToInstance(CreateCategoryDto, {
+        ...validDto,
+        budgetAmount: 0,
+      });
+
+      const errors = await validate(dto);
+      const budgetErrors = errors.filter((e) => e.property === 'budgetAmount');
+
+      expect(budgetErrors).toHaveLength(0);
+    });
+  });
+});

--- a/src/categories/dto/create-category.dto.ts
+++ b/src/categories/dto/create-category.dto.ts
@@ -6,6 +6,7 @@ import {
   IsInt,
   Min,
   MaxLength,
+  Max,
 } from 'class-validator';
 
 export class CreateCategoryDto {
@@ -15,7 +16,7 @@ export class CreateCategoryDto {
   })
   @IsNotEmpty()
   @IsString()
-  @MaxLength(20)
+  @MaxLength(40)
   name: string;
 
   @ApiProperty({
@@ -53,6 +54,7 @@ export class CreateCategoryDto {
   })
   @IsInt()
   @Min(0)
+  @Max(9999999999999)
   budgetAmount: number;
 
   @ApiProperty({

--- a/src/commitments/dto/create-commitment.dto.spec.ts
+++ b/src/commitments/dto/create-commitment.dto.spec.ts
@@ -1,0 +1,54 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { CreateCommitmentDto } from './create-commitment.dto';
+import { TransactionType, CommitmentFrequency } from '@prisma/client';
+
+describe('CreateCommitmentDto', () => {
+  const validDto = {
+    amountCents: 150000,
+    type: TransactionType.EXPENSE,
+    description: 'Monthly rent',
+    date: new Date('2025-05-01T00:00:00Z'),
+    frequency: CommitmentFrequency.MONTHLY,
+    categoryId: 'category-id-test',
+  };
+
+  describe('amountCents @Max constraint', () => {
+    it('should accept amountCents at the maximum value (9999999999999)', async () => {
+      const dto = plainToInstance(CreateCommitmentDto, {
+        ...validDto,
+        amountCents: 9999999999999,
+      });
+
+      const errors = await validate(dto);
+      const amountErrors = errors.filter((e) => e.property === 'amountCents');
+
+      expect(amountErrors).toHaveLength(0);
+    });
+
+    it('should reject amountCents exceeding the maximum value', async () => {
+      const dto = plainToInstance(CreateCommitmentDto, {
+        ...validDto,
+        amountCents: 10000000000000,
+      });
+
+      const errors = await validate(dto);
+      const amountErrors = errors.filter((e) => e.property === 'amountCents');
+
+      expect(amountErrors).toHaveLength(1);
+      expect(amountErrors[0].constraints).toHaveProperty('max');
+    });
+
+    it('should accept amountCents at the minimum value (1)', async () => {
+      const dto = plainToInstance(CreateCommitmentDto, {
+        ...validDto,
+        amountCents: 1,
+      });
+
+      const errors = await validate(dto);
+      const amountErrors = errors.filter((e) => e.property === 'amountCents');
+
+      expect(amountErrors).toHaveLength(0);
+    });
+  });
+});

--- a/src/commitments/dto/create-commitment.dto.ts
+++ b/src/commitments/dto/create-commitment.dto.ts
@@ -7,6 +7,8 @@ import {
   Min,
   IsOptional,
   IsEnum,
+  MaxLength,
+  Max,
 } from 'class-validator';
 import { TransactionType, CommitmentFrequency } from '@prisma/client';
 import { ApiProperty } from '@nestjs/swagger';
@@ -19,6 +21,7 @@ export class CreateCommitmentDto {
   @IsNotEmpty()
   @IsInt()
   @Min(1)
+  @Max(9999999999999)
   amountCents: number;
 
   @ApiProperty({
@@ -36,6 +39,7 @@ export class CreateCommitmentDto {
   })
   @IsNotEmpty()
   @IsString()
+  @MaxLength(60)
   description: string;
 
   @ApiProperty({

--- a/src/common/utils/bigint-transform.ts
+++ b/src/common/utils/bigint-transform.ts
@@ -5,17 +5,19 @@ export const bigintToString = (value: bigint): string => {
   return value.toString();
 };
 
-const brlFormatter = new Intl.NumberFormat('pt-BR', {
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
-
 export const bigintToMoneyString = (value: bigint): string => {
   if (value === null || value === undefined) {
     return '0,00';
   }
-  const valueInReais = value / 100n;
-  return brlFormatter.format(valueInReais);
+  const isNegative = value < 0n;
+  const absoluteValue = isNegative ? -value : value;
+  const reais = absoluteValue / 100n;
+  const cents = absoluteValue % 100n;
+  const formattedReais = reais.toLocaleString('pt-BR');
+  const formattedCents = cents.toString().padStart(2, '0');
+  const valueInReais = `${formattedReais},${formattedCents}`;
+
+  return isNegative ? `-${valueInReais}` : valueInReais;
 };
 
 export const stringToBigint = ({ value }: { value: string }): bigint => {

--- a/src/transactions/dto/create-transaction.dto.spec.ts
+++ b/src/transactions/dto/create-transaction.dto.spec.ts
@@ -1,0 +1,53 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { CreateTransactionDto } from './create-transaction.dto';
+import { TransactionType } from '@prisma/client';
+
+describe('CreateTransactionDto', () => {
+  const validDto = {
+    amountCents: 1059,
+    type: TransactionType.INCOME,
+    description: 'Test transaction',
+    date: new Date('2025-04-21T12:00:00Z'),
+    categoryId: '550e8400-e29b-41d4-a716-446655440000',
+  };
+
+  describe('amountCents @Max constraint', () => {
+    it('should accept amountCents at the maximum value (9999999999999)', async () => {
+      const dto = plainToInstance(CreateTransactionDto, {
+        ...validDto,
+        amountCents: 9999999999999,
+      });
+
+      const errors = await validate(dto);
+      const amountErrors = errors.filter((e) => e.property === 'amountCents');
+
+      expect(amountErrors).toHaveLength(0);
+    });
+
+    it('should reject amountCents exceeding the maximum value', async () => {
+      const dto = plainToInstance(CreateTransactionDto, {
+        ...validDto,
+        amountCents: 10000000000000,
+      });
+
+      const errors = await validate(dto);
+      const amountErrors = errors.filter((e) => e.property === 'amountCents');
+
+      expect(amountErrors).toHaveLength(1);
+      expect(amountErrors[0].constraints).toHaveProperty('max');
+    });
+
+    it('should accept amountCents at the minimum value (1)', async () => {
+      const dto = plainToInstance(CreateTransactionDto, {
+        ...validDto,
+        amountCents: 1,
+      });
+
+      const errors = await validate(dto);
+      const amountErrors = errors.filter((e) => e.property === 'amountCents');
+
+      expect(amountErrors).toHaveLength(0);
+    });
+  });
+});

--- a/src/transactions/dto/create-transaction.dto.ts
+++ b/src/transactions/dto/create-transaction.dto.ts
@@ -5,6 +5,8 @@ import {
   IsDate,
   IsInt,
   Min,
+  Max,
+  IsEnum,
 } from 'class-validator';
 import { TransactionType } from '@prisma/client';
 import { ApiProperty } from '@nestjs/swagger';
@@ -17,6 +19,7 @@ export class CreateTransactionDto {
   @IsNotEmpty()
   @IsInt()
   @Min(1)
+  @Max(9999999999999)
   amountCents: number;
 
   @ApiProperty({
@@ -24,7 +27,7 @@ export class CreateTransactionDto {
     example: 'INCOME',
   })
   @IsNotEmpty()
-  @IsString()
+  @IsEnum(TransactionType)
   type: TransactionType;
 
   @ApiProperty({


### PR DESCRIPTION
This pull request introduces validation improvements and expanded test coverage for DTOs related to categories, commitments, and transactions. It enforces stricter maximum value and length constraints on numeric and string fields, and adds comprehensive tests to ensure these validations work as expected. Additionally, it refines the formatting logic for monetary values.

**Validation enhancements:**

* Added `@Max(9999999999999)` constraint to `amountCents` in `CreateTransactionDto` and `CreateCommitmentDto`, and to `budgetAmount` in `CreateCategoryDto`, ensuring these fields cannot exceed 13 digits.
* Increased `name` max length in `CreateCategoryDto` from 20 to 40, and added `@MaxLength(60)` to `description` in `CreateCommitmentDto` for better flexibility and consistency.
* Changed `type` in `CreateTransactionDto` to use `@IsEnum(TransactionType)` for stricter type validation.

**Test coverage improvements:**

* Added unit tests for `@Max` constraints on `amountCents` in `CreateTransactionDto` and `CreateCommitmentDto`, and on `budgetAmount` in `CreateCategoryDto`, covering edge cases for maximum and minimum values.

**Utility and formatting updates:**

* Refactored `bigintToMoneyString` to improve formatting of negative and large values, ensuring correct display with Brazilian locale and proper handling of cents.